### PR TITLE
ci: create another deploy workflow to publish _site to S3 in production

### DIFF
--- a/.github/workflows/deploy-s3-prod.yml
+++ b/.github/workflows/deploy-s3-prod.yml
@@ -30,5 +30,5 @@ jobs:
         run: bundle exec jekyll build
       - name: Deploy static site to production S3 bucket
         run: |
-          aws s3 sync ./_site/ s3://mywebtest-prod --delete
+          aws s3 sync ./_site/ s3://mywebprod --delete
 

--- a/.github/workflows/deploy-s3-prod.yml
+++ b/.github/workflows/deploy-s3-prod.yml
@@ -1,11 +1,10 @@
 ---
-name: Deploy _site to S3 (dev)
+name: Deploy _site to S3 (prod)
 on:
-  # XXX this workflow runs only when you have created PR, not push
-  pull_request:
+  # XXX this workflow runs only when you have merged PR to `master`
+  push:
     branches:
-      # indicate the name of the branch
-      - dev
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -29,6 +28,7 @@ jobs:
         run: bundle install
       - name: Build static site
         run: bundle exec jekyll build
-      - name: Deploy static site to development S3 bucket
+      - name: Deploy static site to production S3 bucket
         run: |
-          aws s3 sync ./_site/ s3://mywebtest --delete
+          aws s3 sync ./_site/ s3://mywebtest-prod --delete
+

--- a/.github/workflows/htmlproofer.yml
+++ b/.github/workflows/htmlproofer.yml
@@ -1,0 +1,50 @@
+---
+name: Run htmlproofer
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+    branches:
+      - master
+      - dev
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+
+      - name: Cache bundler files
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Install ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Install gems
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Build jekyll site
+        run: bundle exec jekyll build
+
+      - name: Run htmlproofer
+        run: bundle exec htmlproofer --empty_alt_ignore --url-ignore "/^#$/" --check-html --assume-extension --disable-external --log-level debug ./_site
+        # --empty_alt_ignore
+        #   If true, ignores images with empty alt attribues.
+        # --url-ignore "/^#$/"
+        #   ignore links to `#`, often used for JavaScript
+        # --assume-extension
+        #   Automatically add extension (e.g. .html) to file paths, to allow
+        #   extensionless URLs (as supported by Jekyll 3 and GitHub Pages).
+        # --disable-external
+        #   Don't run the external link checker, which can take a lot of time.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -1,0 +1,31 @@
+# Deployment
+
+This document describes deployment process.
+
+The site is hosted on AWS S3. S3 has a feature to publish static sites in
+buckets. See [How do I configure an S3 Bucket for static website
+hosting?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/static-website-hosting.html)
+for how it works.
+
+The deployment process is implemented as GitHub Actions. See
+[`.github/workflows`](../.github/workflows).
+
+## Environments
+
+There are two environments for the site:
+
+- `dev`
+- `production`
+
+Each environment has its own S3 bucket. `mywebtest` for `dev`, and
+`mywebtest-prod` for `production`.
+
+When a PR is created, and the target branch is `dev`, the GitHub Actions will
+deploy the changes in the PR to `dev` environment so that you can see changes
+in the PR on S3. This is intended for reviews before publishing the site to
+the production environment. Note that the change will NOT be published in
+`dev` environment until you create a PR for your branch.
+
+When a change is pushed to `master` branch, the GitHub Actions will deploy the
+change to `production` environment. Thus, the change will be published to the
+production.

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -18,7 +18,7 @@ There are two environments for the site:
 - `production`
 
 Each environment has its own S3 bucket. `mywebtest` for `dev`, and
-`mywebtest-prod` for `production`.
+`mywebprod` for `production`.
 
 When a PR is created, and the target branch is `dev`, the GitHub Actions will
 deploy the changes in the PR to `dev` environment so that you can see changes


### PR DESCRIPTION
## What is this change?

an implementation of a fix for #10 

## Why is this change necessary?

to implement a fix for #10.

## Do you need clarification on anything?

deploy-s3-prod will publish _site only when something is pushed to master
branch.

deploy-s3 will pushed _site only when a PR has been created and the target
branch is `dev`. it does not when you push a branch. as such, you cannot see
your changes in your branch before creating a PR.

the name of the bucket for production is `mywebtest-prod`.

the bucket for the production environment must exist.

fixes #10

## Were there any complications while making this change?

The implementation is not per-PR. the last PR always wins, and overwrites the previous one.

## Have you reviewed and updated the documentation for this change? Is new documentation required?

docs/Deployment.md has been added.

## How did you verify this change? Do you need additional tests in CI?

Because the change is in CI process itself, you cannot test it in CI.

## Do you have links to other related issues, or PRs?

see #10 