### PR TITLE
ignore changes inside of /workflows folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .sass-cache
 .jekyll-cache
 .jekyll-metadata
+.github/workflows/
 node_modules
 .jekyll-cache/
 _site/


### PR DESCRIPTION
The intention of this change is to allow two different configurations of the `deploy-s3.yml' file. One in development and the other in production


