### PR TITLE
New S3 bucket

### DIFF
--- a/.github/workflows/deploy-s3-prod.yml
+++ b/.github/workflows/deploy-s3-prod.yml
@@ -30,5 +30,5 @@ jobs:
         run: bundle exec jekyll build
       - name: Deploy static site to production S3 bucket
         run: |
-          aws s3 sync ./_site/ s3://mywebtest-prod --delete
+          aws s3 sync ./_site/ s3://mywebprod --delete
 


### PR DESCRIPTION
called: mywebprod

In S3, I have created:

New S3 bucket
* mywebprod
* Permissions: public available
* Bucket Policy:
  
```


{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "PublicReadGetObject",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::mywebprod/*"
        }
    ]
}
```

In IAM "static-site-deployer-user", I have added new:
* **PERMISSION**
* `static-site-deploy-policy-prod` (same security credentials) with a new policy:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": [
                "s3:ListBucket",
                "s3:GetBucketLocation"
            ],
            "Resource": "arn:aws:s3:::mywebprod"
        },
        {
            "Sid": "VisualEditor1",
            "Effect": "Allow",
            "Action": [
                "s3:PutObject",
                "s3:GetObject",
                "s3:DeleteObject"
            ],
            "Resource": "arn:aws:s3:::mywebprod/*"
        }
    ]
}
```
